### PR TITLE
Fix for latest mocha version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "peerDependencies": {
     "mongodb": "~1",
-    "mocha": "~1"
+    "mocha": ">=1.0.0"
   },
   "devDependencies": {
     "mocha": "~1",


### PR DESCRIPTION
Mocha is now running on 2.x.x, and mocha-mongoose is not working anymore:

```
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package mocha does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer mocha-mongoose@1.0.2 wants mocha@~1
```
