### PR TITLE
Update mongo-connection protocol

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ module.exports = function(uriString, options) {
   }
 
   if (!uriString) {
-    console.warn("!WARNING: no mongodb url provided.  Defaulting to mongo://localhost/test");
-    uriString = 'mongo://localhost/test';
+    console.warn("!WARNING: no mongodb url provided.  Defaulting to mongodb://localhost/test");
+    uriString = 'mongodb://localhost/test';
   }
 
   var db = null;


### PR DESCRIPTION
If I didn't provide any URL, I got the following error

```
!WARNING: no mongodb url provided.  Defaulting to mongo://localhost/test

Error: URL must be in the format mongodb://user:pass@host:port/dbname
```