### PR TITLE
Added a function to close the database in the after hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var url    = require('url')
 ;
 
 var beforeEachRegistered = false;
+var afterHookRegistered = false;
 
 module.exports = function(uriString, options) {
   options = options || {};
@@ -23,6 +24,14 @@ module.exports = function(uriString, options) {
       // we're in a test suite that hopefully supports async operations
       beforeEach(clearDB);
       beforeEachRegistered = true;
+    }
+  }
+
+  if (!options.noClear && !afterHookRegistered) {
+    if ('function' == typeof after && after.length > 0) {
+      // we're in a test suite that hopefully supports async operations
+      after(closeDB);
+      afterHookRegistered = true;
     }
   }
 
@@ -57,5 +66,9 @@ module.exports = function(uriString, options) {
         });
       });
     });
+  }
+
+  function closeDB() {
+    db.close();
   }
 };


### PR DESCRIPTION
The reason for this PR is because I was having some issues where mocha would not exit cleanly because there were still connections open to the database. By calling close on the database it resolves this issue and mocha can exit cleanly. 

You can see here https://mongodb.github.io/node-mongodb-native/api-generated/mongoclient.html#mongoclient-connect that they do the same thing after they open a connection.

I wasn't sure how to even test this, so I didn't add any tests sorry.