### PR TITLE
Add skip option to allow skip clearing specific collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ See the example spec (copied below) for more details.
     require('mocha-mongoose')('mongodb://your-mongodb-url-here');
 
 1. mocha-mongoose will automatically clear all of your collections before each spec run
+1. optionally provide a `skip` option to tell mocha-mongoose not to clear specific collections.
+    require('mocha-mongoose')(dbURI, { skip: ['collectionname1', 'collectionname2'] });
 
 ## Example usage of automatically clearing the DB between specs:
 

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ module.exports = function(uriString, options) {
 
       collections.forEach(function(collection){
         if (collection.collectionName.match(/^system\./)) return --todo;
+        if (options.skip instanceof Array && options.skip.indexOf(collection.collectionName) > -1) return --todo;
 
         collection.remove({},{safe: true}, function(){
           if (--todo === 0) done();

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ var uniqueId = 'c90b6960-0109-11e2-9595-00248c45df8a'
   , expect   = require('chai').expect
   , mongoose = require('mongoose')
   , Dummy    = mongoose.model('Dummy', new mongoose.Schema({a:Number}))
+  , ImmortalDummy = mongoose.model('ImmortalDummy', new mongoose.Schema({a:Number}))
 ;
 
 
@@ -37,6 +38,39 @@ describe("clearDB", function() {
             Dummy.find({}, function(err, docs){
               expect(err).to.not.exist;
               expect(docs).to.have.length(0);
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    describe("when required with the skip option", function() {
+      beforeEach(function(done) {
+        options.skip = ['immortaldummies']
+        clearDB = require('../index')(dbURI, options);
+
+        Dummy.create({a: 1}, function(err){
+          if (err) return done(err);
+
+          ImmortalDummy.create({a: 1}, function(err){
+            if (err) return done(err);
+
+            done();
+          });
+        });
+      });
+
+      it("does not clear the skipped collections", function(done) {
+        clearDB(function(err){
+          Dummy.find({}, function(err, docs){
+            expect(err).to.not.exist;
+            expect(docs).to.have.length(0);
+
+            ImmortalDummy.find({}, function(err, docs){
+              expect(err).to.not.exist;
+              expect(docs).to.have.length.above(0);
+
               done();
             });
           });


### PR DESCRIPTION
Hi,

First of all thanks a lot for making this library. It helps a lot in my day-to-day work.

This PR adds a `skip` option to tell `mocha-mongoose` to skip specific collections when it clears the DB. For example:

```
require('mocha-mongoose')(dbURI, { skip: ['collectionname1', 'collectionname2'] });
```

This is especially useful when you have some pre-populated collections (via migrations etc) and you don't want to re-run migrations for each test case when you add `mocha-mongoose`.
