### PR TITLE
Make a db reference available to tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = function(uriString, options) {
       if (err) return done(err);
 
       db = newDb;
+      module.exports.db = db;
 
       clearCollections(done);
     });


### PR DESCRIPTION
Our code stashes a mongodb db reference into the request via middleware, the request handlers then query mongodb using that reference. I'm trying to test the handlers using mocha-mongoose. Mocha-mongoose does have a db reference internally but it is not exposed to the tests in any way. Since the db connection must be established asynchronously duplicating MM's logic in our tests would involve a fair bit of code and I'd rather not do that.

Attached is a quick PR I put together to put `db` on the exposed function. Thoughts?