### PR TITLE
set max mongodb version to 3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "chai": ">=1.0.0",
     "mocha": ">= 1.0.0",
     "mongodb": ">=1.0.0",
-    "mongoose": ">=3.0.0",
+    "mongoose": "^3.0.0",
     "nodemon": "~0"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "peerDependencies": {
     "mocha": ">=1.0.0",
-    "mongodb": ">=1.0.0"
+    "mongodb": ">=1.0.0, <3"
   },
   "devDependencies": {
     "chai": ">=1.0.0",


### PR DESCRIPTION
mongodb 3 isn't supported anymore:

> MongoClient.connect now returns a Client instead of a DB.

https://mongodb.github.io/node-mongodb-native/3.0/upgrade-migration/main/
https://github.com/mongodb/node-mongodb-native/blob/3.0.0/CHANGES_3.0.0.md